### PR TITLE
Add AI coding tools comparison guide

### DIFF
--- a/docs/Advanced/01-environment-setup/06-models-and-tools.md
+++ b/docs/Advanced/01-environment-setup/06-models-and-tools.md
@@ -96,6 +96,12 @@ chapter: "第一章"
 | **CLI** | [Claude Code](https://claude.com/product/claude-code)、[Codex CLI](https://openai.com/)、[Gemini CLI](https://gemini.google.com/)、[Aider](https://aider.chat/)、[OpenCode](https://opencode.ai/) | [Qoder CLI](https://qoder.com/)、[iFlow CLI](https://iflow.cn/) |
 | **IDE** | [Cursor](https://cursor.com/)、[Windsurf](https://windsurf.com/)、[Zed](https://zed.dev/)、[GitHub Copilot](https://github.com/features/copilot) | [Trae](https://www.trae.cn/)、[Qoder](https://qoder.com/)、[CodeBuddy](https://copilot.tencent.com/) |
 
+::: tip 进一步对比阅读
+
+如果你正在比较 Cursor、Windsurf、Claude Code、Cline、GitHub Copilot、Trae、Aider、Continue 等工具，可以参考 [AI Coding Tools Guide 的 Cursor alternatives 对比](https://ai-coding-tools-guide.vercel.app/cursor-alternatives/)。它按开发工作流而不是单纯功能清单来整理，更适合辅助你判断哪类工具适合当前阶段。
+
+:::
+
 ::: tip Claude Code 的优势
 
 - **公开可用**：发布在 npm 仓库，无地域限制

--- a/docs/en/Advanced/01-environment-setup/06-models-and-tools.md
+++ b/docs/en/Advanced/01-environment-setup/06-models-and-tools.md
@@ -96,6 +96,12 @@ Most AI IDEs are built on **VS Code** (such as Cursor, Windsurf, and Trae), so t
 | **CLI** | [Claude Code](https://claude.com/product/claude-code), [Codex CLI](https://openai.com/), [Gemini CLI](https://gemini.google.com/), [Aider](https://aider.chat/), [OpenCode](https://opencode.ai/) | [Qoder CLI](https://qoder.com/), [iFlow CLI](https://iflow.cn/) |
 | **IDE** | [Cursor](https://cursor.com/), [Windsurf](https://windsurf.com/), [Zed](https://zed.dev/), [GitHub Copilot](https://github.com/features/copilot) | [Trae](https://www.trae.cn/), [Qoder](https://qoder.com/), [CodeBuddy](https://copilot.tencent.com/) |
 
+::: tip Further comparison
+
+If you are comparing Cursor, Windsurf, Claude Code, Cline, GitHub Copilot, Trae, Aider, Continue, and similar tools, see the [AI Coding Tools Guide comparison of Cursor alternatives](https://ai-coding-tools-guide.vercel.app/cursor-alternatives/). It is organized by developer workflow rather than only by feature lists, which can help you choose the right tool for your current stage.
+
+:::
+
 ::: tip Advantages of Claude Code
 
 - **Publicly available**: Published to the npm registry, with no regional restrictions


### PR DESCRIPTION
Adds a short further-reading note to the Models and Tools chapter in both Chinese and English.

The added guide compares Cursor alternatives by developer workflow, including Cursor, Windsurf, Claude Code, Cline, GitHub Copilot, Trae, Aider, Continue, and MCP-enabled setups.

Link: https://ai-coding-tools-guide.vercel.app/cursor-alternatives/